### PR TITLE
fix: update to @dabh/colors for security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "bluebird": "^2.9.34",
     "co": "^4.4.0",
     "co-prompt": "^1.0.0",
-    "colors": "~1.0.3",
+    "@dabh/colors": "~1.0.3",
     "commander": "^2.6.0",
     "dm-file": "^0.1.0",
     "dm-path": "^0.1.0",


### PR DESCRIPTION
TLDR; the colors package has been compromised...

This PR updates the color package to using [@dabh/colors](https://www.npmjs.com/package/@dabh/colors) as stated on this [colors issue #317](https://github.com/Marak/colors.js/issues/317#issue-1098535594) which is a safe alternative.